### PR TITLE
Re-implement list products endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -220,9 +220,15 @@ def check_content_type(content_type) -> None:
 ######################################################################
 @app.route("/products", methods=["GET"])
 def list_products():
-    """Returns all Products"""
-    products = Product.all()
+    """
+    List all Products
+
+    This endpoint returns a list of products, capped at 50 results
+    """
+    app.logger.info("Request to list Products...")
+    products = Product.query.limit(50).all()
     results = [product.serialize() for product in products]
+    app.logger.info("Returning %d products", len(results))
     return jsonify(results), status.HTTP_200_OK
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -203,7 +203,34 @@ class TestYourResourceService(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    # Todo: Add your test cases here...
+    # ----------------------------------------------------------
+    # TEST LIST
+    # ----------------------------------------------------------
+    def test_list_products(self):
+        """It should return a list of Products"""
+        self._create_products(5)
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 5)
+
+    def test_list_products_empty(self):
+        """It should return an empty list when no Products exist"""
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 0)
+
+    def test_list_products_limit(self):
+        """It should return at most 50 Products"""
+        self._create_products(55)
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertIsInstance(data, list)
+        self.assertLessEqual(len(data), 50)
 
     def test_delete_product(self):
         """It should Delete a Product"""
@@ -221,14 +248,6 @@ class TestYourResourceService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         data = response.get_json()
         self.assertIn("not found", data["message"])
-
-    def test_list_products(self):
-        """It should list all Products"""
-        self._create_products(3)
-        response = self.client.get(BASE_URL)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.get_json()
-        self.assertEqual(len(data), 3)
 
     def test_update_product_not_found(self):
         """It should not update a product that is not found"""


### PR DESCRIPTION
Replace the previous list_products implementation with a version that caps results at 50 products as defined in the story and includes request logging. Add comprehensive tests covering happy path, empty list, and the 50-product limit.