### PR TITLE
Deploy PostgreSQL to OpenShift (closes #64)

### DIFF
--- a/k8s/postgres/secret.yaml
+++ b/k8s/postgres/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+  labels:
+    app: postgres
+type: Opaque
+stringData:
+  POSTGRES_USER: postgres
+  POSTGRES_DB: products
+  POSTGRES_PASSWORD: pgs3cr3t
+  DATABASE_URI: "postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/products"

--- a/k8s/postgres/service.yaml
+++ b/k8s/postgres/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app: postgres
+    

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: postgres-creds
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U postgres -d products
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U postgres -d products
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
## Summary
Adds Kubernetes manifests to deploy PostgreSQL as a StatefulSet in OpenShift, providing the persistence layer for the products microservice.

## Changes
- `k8s/postgres/secret.yaml` — credentials and `DATABASE_URI` connection string
- `k8s/postgres/statefulset.yaml` — PostgreSQL 15 StatefulSet with 1Gi PVC, readiness/liveness probes
- `k8s/postgres/service.yaml` — ClusterIP service exposing `postgres:5432`

## Verification
Deployed to `liwelaine-dev` on OpenShift ROSA:
- `oc get pods` → `postgres-0   1/1   Running`
- `oc exec -it postgres-0 -- psql -U postgres -d products -c "\l"` → confirmed `products` DB exists

## Interface Contract (for app deployment story)
- Secret name: `postgres-creds`
- Key to consume: `DATABASE_URI`
- Service DNS: `postgres:5432`
- Database name: `products`

## Scope
Delivers the **database infrastructure layer only**. End-to-end verification that the microservice connects on startup is deferred to the app deployment story.

Closes #64