### PR TITLE
Create OpenShift Route for products microservice (closes #63)

### DIFF
--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: products
+  labels:
+    app: products
+spec:
+  to:
+    kind: Service
+    name: products
+    weight: 100
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None


### PR DESCRIPTION
## Summary
Adds an OpenShift Route manifest to expose the products microservice externally once it's deployed.

## Changes
- `k8s/route.yaml` — Route targeting `products` Service on port 8080
- Uses edge TLS termination so clients access via HTTPS
- `insecureEdgeTerminationPolicy: Redirect` auto-redirects HTTP → HTTPS

## Verification
Validated via dry-run:
- `oc apply -f k8s/route.yaml --dry-run=client` → `route.route.openshift.io/products created (dry run)` ✅

## Interface (for BDD / Tekton pipeline)
Once active, retrieve the external URL via:
`oc get route products -o jsonpath='{.spec.host}'`

Use this as `BASE_URL` for Behave BDD tests.

## Scope
Delivers the Route manifest only. The Route will become active once the `products` Service is deployed (separate story).

Closes #63