### PR TITLE
Add pytest-env test task to CD pipeline (closes #65)

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -71,6 +71,24 @@ spec:
       workspaces:
         - name: source
           workspace: products-pipeline-workspace
+    - name: tests
+      runAfter:
+        - git-clone
+      taskRef:
+        name: pytest-env
+        kind: Task
+      params:
+        - name: pytest-args
+          value:
+            - "-v"
+            - "--cov=service"
+        - name: secret-name
+          value: "postgres-creds"
+        - name: secret-key
+          value: "DATABASE_URI"
+      workspaces:
+        - name: source
+          workspace: products-pipeline-workspace
   workspaces:
     - name: products-pipeline-workspace
   finally: []


### PR DESCRIPTION
## Summary
Adds the `tests` task to the CD pipeline so unit tests run automatically on every pipeline trigger, in parallel with the `lint` task per HW2 Requirement 6.

## Changes
- `.tekton/pipeline.yaml` — added `tests` task after `git-clone`

## Parallel Execution
Both `lint` and `tests` use `runAfter: [git-clone]` (not `runAfter: [lint]`), so they run in parallel.

Per HW2 Req 6:
> "Make sure that you lint task and test task run in parallel to minimize time spent running checks."

## Task Configuration
- Uses `pytest-env` Task already defined in `.tekton/tasks.yaml`
- Passes `-v` and `--cov=service` for verbose output and coverage
- References `postgres-creds` Secret for `DATABASE_URI`
- Explicitly sets `secret-key: "DATABASE_URI"` (uppercase) to match the Secret. The default in `pytest-env` is lowercase `database_uri` which wouldn't match.

## Verification
YAML structure verified — task is properly nested under `spec.tasks` with correct workspace bindings.

Closes #65