### PR TITLE
Add Build Image to CD Pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -11,6 +11,10 @@ spec:
       description: The reference (branch or ref)
       name: GIT_REF
       type: string
+    - description: The fully qualified image reference to build and push (e.g. image-registry.openshift-image-registry.svc:5000/<namespace>/products:<tag>)
+      name: IMAGE_NAME
+      type: string
+      default: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/products:latest
   tasks:
     - name: git-clone
       params:
@@ -86,6 +90,33 @@ spec:
           value: "postgres-creds"
         - name: secret-key
           value: "DATABASE_URI"
+      workspaces:
+        - name: source
+          workspace: products-pipeline-workspace
+    - name: build
+      runAfter:
+        - lint
+        - tests
+      taskRef:
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: buildah
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: DOCKERFILE
+          value: ./Dockerfile
+        - name: CONTEXT
+          value: .
+        - name: TLSVERIFY
+          value: "false"
+        - name: STORAGE_DRIVER
+          value: vfs
       workspaces:
         - name: source
           workspace: products-pipeline-workspace


### PR DESCRIPTION
Adds a build step to the Tekton CD pipeline so that, after lint and tests succeed, the repo is built into a container image via the OpenShift-provided buildah ClusterTask (cluster resolver) and pushed using the IMAGE_NAME parameter (wired to match the webhook trigger’s internal registry tagging).